### PR TITLE
Improved support for NME's URLLoader in HttpLoader

### DIFF
--- a/src/mloader/HttpLoader.hx
+++ b/src/mloader/HttpLoader.hx
@@ -69,7 +69,7 @@ class HttpLoader<T> extends LoaderBase<T>
 		super(url);
 		
 		headers = new Hash();
-		
+
 		#if nme
 		urlRequest = new flash.net.URLRequest();
 		loader = new flash.net.URLLoader();
@@ -177,12 +177,12 @@ class HttpLoader<T> extends LoaderBase<T>
 	}
 
 	//-------------------------------------------------------------------------- private
-
+	
 	override function loaderLoad()
 	{
 		httpConfigure();
 		addHeaders();
-
+		
 		#if nme
 		urlRequest.url = url;
 		if (url.indexOf("http:") == 0 || url.indexOf("https:") == 0)
@@ -227,7 +227,7 @@ class HttpLoader<T> extends LoaderBase<T>
 		http.cancel();
 		#end
 	}
-	
+
 	function httpConfigure()
 	{
 		// abstract


### PR DESCRIPTION
This adds the following improvements to HttpLoader under NME when using it's URLLoader:
- Support calls to https urls
- Capture and ignore exception raised when closing a URLLoader which is not active
- Listen and report security errors
- Listen and report change in http status code
