### PR TITLE
Update ImageLoader.hx

### DIFF
--- a/src/mloader/ImageLoader.hx
+++ b/src/mloader/ImageLoader.hx
@@ -64,6 +64,7 @@ class ImageLoader extends LoaderBase<js.Dom.Image>
 			content = image;
 		}
 		
+		#if !haxe3 untyped #end content.crossOrigin = "Anonymous";
 		content.onload = imageLoad;
 		content.onerror = imageError;
 		content.src = url;


### PR DESCRIPTION
I recently had an issue where images served from a domain which I own would cause the browser to mark any canvas they were rendered into to become "tainted".  I have the correct HTTP headers regarding cross-origin-policies on the server, but the problem still persisted.  

I then found the following article:

Further info @ http://blog.chromium.org/2011/07/using-cross-domain-images-in-webgl-and.html

After making the changes to the mLoader lib, my app works as intended.  I figured the commit might be worth merging back into your repo.
