### PR TITLE
Access server responseData if applicable.

### DIFF
--- a/src/mloader/HttpLoader.hx
+++ b/src/mloader/HttpLoader.hx
@@ -268,6 +268,7 @@ class HttpLoader<T> extends LoaderBase<T>
 	
 	function httpError(error:String)
 	{
+		content = cast http.responseData;
 		loaderFail(IO(error));
 	}
 	


### PR DESCRIPTION
Upon IO Error this change allows access to the `responseData` from the server.

e.g. MISL returns a `400 Bad Request` along with relevant info which is usually lost.

```
{"odata.error":{"code":"","message":{"lang":"en-US","value":"An account with this email address already exists."},"validation.errors":[{"Property":"Email","Rule":"MustBeUnique"}]}} 
```
