### PR TITLE
ImageLoader works with openfl html target

### DIFF
--- a/src/mloader/ImageLoader.hx
+++ b/src/mloader/ImageLoader.hx
@@ -25,7 +25,7 @@ package mloader;
 import mloader.Loader;
 import msignal.EventSignal;
 
-#if js
+#if (js && !(nme || openfl))
 /**
 Loads an image at a defined url.
 */


### PR DESCRIPTION
Conditional compilation flags were incorrect when compiling for the HTML target in Openfl.
