### PR TITLE
Flash: added LoaderContext.checkPolicyFile to ImageLoader request

### DIFF
--- a/src/mloader/ImageLoader.hx
+++ b/src/mloader/ImageLoader.hx
@@ -133,7 +133,8 @@ class ImageLoader extends LoaderBase<BitmapData>
 			loaderComplete();
 		}
 		#else
-		loader.load(new flash.net.URLRequest(url));
+		var loaderContext = new flash.system.LoaderContext(true);
+		loader.load(new flash.net.URLRequest(url), loaderContext);
 		#end
 	}
 


### PR DESCRIPTION
Adds a simple LoaderContext to the loader.load in ImageLoader (flash target only).

This is required because ImageLoader accesses the bitmapData directly, which throws a Security Sandbox exception when loading from another domain with a valid crossdomain.xml

```
override function loaderLoad()
{
    ...
    var loaderContext = new flash.system.LoaderContext(true);
    loader.load(new flash.net.URLRequest(url), loaderContext);
    ...
}
```
