### PR TITLE
Add null check to content before accessing properties

### DIFF
--- a/src/mloader/ImageLoader.hx
+++ b/src/mloader/ImageLoader.hx
@@ -70,14 +70,13 @@ class ImageLoader extends LoaderBase<LoadableImage>
 
 	override function loaderCancel():Void
 	{
+		content.onload = null;
+		content.onerror = null;
 		content.src = "";
 	}
 
 	function imageLoad(event)
 	{
-		if (content == null)
-			return;
-
 		content.onload = null;
 		content.onerror = null;
 		loaderComplete();


### PR DESCRIPTION
Resolves an issue on low power devices (tested specifically on Sony TV) whereby spamming an Image loader queue with requests would cause a runtime exception, caused by a null object reference to `content`. A null check prevents the runtime exception.

@ReDrUm 
