### PR TITLE
ImageLoader: Fix issue where cached images are not always triggering onload

### DIFF
--- a/src/mloader/ImageLoader.hx
+++ b/src/mloader/ImageLoader.hx
@@ -67,7 +67,6 @@ class ImageLoader extends LoaderBase<LoadableImage>
 		content.onerror = imageError;
 		content.src = url;
 		
-		#if js
 		// Browsers can fail to trigger onload when the image is in cache.
 		// This check determines if the image has loaded synchronously without
 		// triggering an event handler, and if so manually calls loaderComplete().
@@ -78,7 +77,6 @@ class ImageLoader extends LoaderBase<LoadableImage>
 			content.onerror = null;
 			loaderComplete();
 		}
-		#end
 	}
 
 	override function loaderCancel():Void

--- a/src/mloader/ImageLoader.hx
+++ b/src/mloader/ImageLoader.hx
@@ -66,6 +66,19 @@ class ImageLoader extends LoaderBase<LoadableImage>
 		content.onload = imageLoad;
 		content.onerror = imageError;
 		content.src = url;
+		
+		#if js
+		// Browsers can fail to trigger onload when the image is in cache.
+		// This check determines if the image has loaded synchronously without
+		// triggering an event handler, and if so manually calls loaderComplete().
+		// https://code.google.com/p/chromium/issues/detail?id=7731
+		if (content.complete == true && content.onload != null)
+		{
+			content.onload = null;
+			content.onerror = null;
+			loaderComplete();
+		}
+		#end
 	}
 
 	override function loaderCancel():Void


### PR DESCRIPTION
We're coming across situations in our browser apps where images are sometimes failing to load if they've been loaded previously. This seems to be Chrome, if not webkit specific.

https://code.google.com/p/chromium/issues/detail?id=7731

The fix here checks the `img.complete` flag. If this is true after the `src` has been set then the image must have been loaded instantly from cache. See https://developer.mozilla.org/en/docs/Web/API/HTMLImageElement. In this situation we check to see if an event handler has fired, and if not we kill img listeners and call loaderComplete directly. 

Id did try checking to see if `img.src == url` before its set but that doesn't seem to be an indicator of the issue.

One point here is that the completed signal of the loader may fire synchronously after the call to load the image. I don't see this being a likely problem, but one worth mentioning.

With tests done this seems to make images appear that little bit faster that are coming from cache, assuming they appeared before.

More info and links to live examples [here](https://agile.massiveinteractive.com/browse/MASVSN-906).