### PR TITLE
fix: remove custom property accessors for haxe 4 support

### DIFF
--- a/src/mloader/Loader.hx
+++ b/src/mloader/Loader.hx
@@ -39,7 +39,7 @@ interface Loader<T>
 	/**
 	The url to load the resource from.
 	*/
-	var url(default, set_url):String;
+	var url(default, set):String;
 
 	/**
 	The percentage of loading complete. Between 0 and 1.

--- a/src/mloader/LoaderBase.hx
+++ b/src/mloader/LoaderBase.hx
@@ -34,7 +34,7 @@ class LoaderBase<T> implements Loader<T>
 	/**
 	The current url of the loader.
 	*/
-	public var url(default, set_url):String;
+	public var url(default, set):String;
 
 	/**
 	If the url changes while loading, cancel the request.

--- a/src/mloader/LoaderQueue.hx
+++ b/src/mloader/LoaderQueue.hx
@@ -93,19 +93,19 @@ class LoaderQueue implements Loader<Array<Loader<Dynamic>>>
 	/**
 	The current size of the queue. Includes both active and pending Loaders.
 	*/
-	public var size(get_size, null):Int;
+	public var size(get, null):Int;
 	function get_size() { return pendingQueue.length + activeLoaders.length; }
 
 	/**
 	The number of Loaders sitting in the queue waiting to start their loading.
 	*/
-	public var numPending(get_numPending, null):Int;
+	public var numPending(get, null):Int;
 	function get_numPending() { return pendingQueue.length; }
 
 	/**
 	The number of loaders currently loading.
 	*/
-	public var numLoading(get_numLoading, null):Int;
+	public var numLoading(get, null):Int;
 	function get_numLoading() { return activeLoaders.length; }
 
 	/**
@@ -130,7 +130,7 @@ class LoaderQueue implements Loader<Array<Loader<Dynamic>>>
 	This value is not used by the LoaderQueue. Added to adhere to the Loader 
 	interface.
 	*/
-	public var url(default, set_url):String;
+	public var url(default, set):String;
 	function set_url(value:String):String { return value; }
 
 	var pendingQueue:Array<PendingLoader>;


### PR DESCRIPTION
On Haxe version 4.0.0-preview.5+7eb789f54, this error appears: `Custom property accessor is no longer supported, please use set`. This should fix it.