### PR TITLE
Specifying ProgressEvent in event handlers for unify error

### DIFF
--- a/src/mloader/ImageLoader.hx
+++ b/src/mloader/ImageLoader.hx
@@ -154,7 +154,7 @@ class ImageLoader extends LoaderBase<LoadableImage>
 		#end
 	}
 	
-	function loaderProgressed(event)
+	function loaderProgressed(event:flash.events.ProgressEvent)
 	{
 		progress = 0.0;
 

--- a/src/mloader/SwfLoader.hx
+++ b/src/mloader/SwfLoader.hx
@@ -58,7 +58,7 @@ class SwfLoader extends LoaderBase<flash.display.DisplayObject>
 		loader.close();
 	}
 	
-	function loadProgress(event)
+	function loadProgress(event:flash.events.ProgressEvent)
 	{
 		progress = 0.0;
 


### PR DESCRIPTION
I was getting the following error after upgrading to OpenFl 8,9,1:

```
mloader/src/mloader/ImageLoader.hx:123: characters 67-83 : event : { bytesTotal : Int, bytesLoaded : Int } -> Void should be openfl.events.ProgressEvent -> Void
mloader/src/mloader/ImageLoader.hx:123: characters 67-83 : Cannot unify argument 1
mloader/src/mloader/ImageLoader.hx:123: characters 67-83 : openfl.events.ProgressEvent should be { bytesTotal : Int, bytesLoaded : Int }
mloader/src/mloader/ImageLoader.hx:123: characters 67-83 : Invalid type for field bytesLoaded :
mloader/src/mloader/ImageLoader.hx:123: characters 67-83 : Float should be Int
mloader/src/mloader/ImageLoader.hx:123: characters 67-83 : For function argument 'listener'
```

Specifying ProgressEvent in the handlers seems to have solved this.