### PR TITLE
Replacing deprecated Std.is with Std.isOfType

### DIFF
--- a/src/mloader/HttpLoader.hx
+++ b/src/mloader/HttpLoader.hx
@@ -154,19 +154,19 @@ class HttpLoader<T> extends LoaderBase<T>
 		// default content type
 		var contentType = "application/octet-stream";
 
-		if (Std.is(data, Xml))
+		if (Std.isOfType(data, Xml))
 		{
 			// convert to string and send as application/xml
 			data = Std.string(data);
 			contentType = "application/xml";
 		}
-		else if (!Std.is(data, String))
+		else if (!Std.isOfType(data, String))
 		{
 			// stringify and send as application/json
 			data = haxe.Json.stringify(data);
 			contentType = "application/json";
 		}
-		else if (Std.is(data, String) && validateJSONdata(data))
+		else if (Std.isOfType(data, String) && validateJSONdata(data))
 		{
 			//data is already a valid JSON string
 			contentType = "application/json";

--- a/test/mloader/XmlLoaderTest.hx
+++ b/test/mloader/XmlLoaderTest.hx
@@ -80,7 +80,7 @@ class XmlLoaderTest
 		loader.load();
 		
 		Assert.isTrue(Type.enumEq(events[0].type, Complete));
-		Assert.isTrue(Std.is(loader.content, Xml));
+		Assert.isTrue(Std.isOfType(loader.content, Xml));
 		Assert.areEqual(xml.toString(), loader.content.toString());
 	}
 
@@ -98,7 +98,7 @@ class XmlLoaderTest
 
 
 		Assert.isTrue(Type.enumEq(events[0].type, Complete));
-		Assert.isTrue(Std.is(loader.content, Xml));
+		Assert.isTrue(Std.isOfType(loader.content, Xml));
 		Assert.areEqual(xml.firstChild().toString(), loader.content.toString());
 	}
 


### PR DESCRIPTION
Small change to get rid of the deprecation notices.